### PR TITLE
refactor: simplify Home page layout and Hero section

### DIFF
--- a/apps/frontend/src/pages/Home/Home.tsx
+++ b/apps/frontend/src/pages/Home/Home.tsx
@@ -1,162 +1,73 @@
-import { CTA } from '@/components/CTA/CTA.tsx';
-import { withPreviewData, withPublishedData } from '@/components/withDocument.tsx';
-import { POSTS_PER_PAGE } from '@/constants/config.ts';
-// Interne utilities
-import { Route } from '@/routes/index.tsx';
-import { client } from '@/sanity/client.ts';
-import { STUDIO_BASEPATH } from '@/sanity/constants.ts';
-import { homeQuery } from '@/sanity/queries/homeQuery.ts';
-import { getPostsQuery } from '@/sanity/queries/postQuery.ts';
-import { previewStore } from '@/stores/previewStore.ts';
-import type { PageProps } from '@/types/PageProps.ts';
-import type { CategoryStub } from '@/types/category.ts';
-import type { HomeDocument } from '@/types/home.ts';
-import type { PostStub } from '@/types/post.ts';
-import { useInfiniteQuery } from '@tanstack/react-query';
-import { useStore } from '@tanstack/react-store';
-// Stiler
-import { divider, homeContainer } from './Home.css.ts';
-import { ArchitectureSection } from './sections/ArchitectureSection.tsx';
-import { CategoriesSection } from './sections/CategoriesSection.tsx';
-import { ContentCardsSection } from './sections/ContentCardsSection.tsx';
-import { DevExpSection } from './sections/DevExpSection.tsx';
-// Typer
-import { HeroSection } from './sections/HeroSection.tsx';
-import { HighlightsSection } from './sections/HighlightsSection.tsx';
-import { PostsSection } from './sections/PostsSection.tsx';
+import {
+  withPreviewData,
+  withPublishedData,
+} from "@/components/withDocument.tsx";
+// Internal utilities
+import { Route } from "@/routes/index.tsx";
+import { homeQuery } from "@/sanity/queries/homeQuery.ts";
+import { previewStore } from "@/stores/previewStore.ts";
+import type { PageProps } from "@/types/PageProps.ts";
+import type { HomeDocument } from "@/types/home.ts";
+import { useStore } from "@tanstack/react-store";
+// Styles
+import { divider, homeContainer } from "./Home.css.ts";
+
+import { ContentCardsSection } from "./sections/ContentCardsSection.tsx";
+// Types
+import { HeroSection } from "./sections/HeroSection.tsx";
 
 type HomePagePayload = {
-	categoriesData: Array<CategoryStub>;
-	postsData: Array<PostStub>;
-	homeData: HomeDocument;
+  homeData: HomeDocument;
 };
 
 const Home = ({ data }: PageProps<HomePagePayload>) => {
-	// Read isPreview from the reactive store instead of props
-	// This ensures it updates when GlobalLayout detects preview mode
-	const { isPreview } = useStore(previewStore);
+  const homeData = data?.homeData ?? {
+    title: null,
+    subTitle: null,
+    headingCard1: null,
+    headingCard2: null,
+    headingCard3: null,
+    card1: null,
+    card2: null,
+    card3: null,
+  };
 
-	const {
-		data: listData,
-		fetchNextPage,
-		hasNextPage,
-		isFetchingNextPage,
-	} = useInfiniteQuery({
-		queryKey: ['posts', isPreview ? 'preview' : 'published'],
-		enabled: !isPreview, // Only use infinite query when NOT in preview mode
-		initialPageParam: {
-			pageNumber: 0,
-			lastId: data?.postsData[data.postsData.length - 1]?._id,
-			lastPublishedAt: data?.postsData[data.postsData.length - 1]?.publishedAt,
-		},
-		getNextPageParam: (lastPage, allPages) =>
-			lastPage && lastPage.length < POSTS_PER_PAGE
-				? undefined
-				: {
-						pageNumber: allPages.length,
-						lastPublishedAt: lastPage?.[lastPage.length - 1]?.publishedAt,
-						lastId: lastPage?.[lastPage.length - 1]?._id,
-					},
-		queryFn: async ({ pageParam }) => {
-			// This should only run when NOT in preview mode
-			if (isPreview) {
-				throw new Error('Infinite query should not run in preview mode');
-			}
-
-			const { lastId, lastPublishedAt } = pageParam;
-			return await client
-				.withConfig({
-					stega: { enabled: false, studioUrl: STUDIO_BASEPATH },
-					resultSourceMap: false,
-					// Never use perspective in infinite query - always published
-					perspective: 'published',
-				})
-				.fetch(getPostsQuery(POSTS_PER_PAGE), {
-					lastPublishedAt: lastPublishedAt || null,
-					lastId: lastId || null,
-				});
-		},
-		initialData: !isPreview
-			? {
-					pages: [data?.postsData],
-					pageParams: [{ pageNumber: 0, lastPublishedAt: null, lastId: null }],
-				}
-			: undefined,
-		// Ensure query doesn't refetch when isPreview changes
-		refetchOnMount: false,
-		refetchOnWindowFocus: false,
-		refetchOnReconnect: false,
-	});
-
-	// In preview mode, use data from server (which has live updates)
-	// In production, use infinite query data (which has pagination)
-	const posts: Array<PostStub> = isPreview ? (data?.postsData ?? []) : (listData.pages.flat() as Array<PostStub>);
-	const categories: Array<CategoryStub> = data?.categoriesData ?? [];
-	const homeData = data?.homeData ?? {
-		title: null,
-		subTitle: null,
-		headingCard1: null,
-		headingCard2: null,
-		headingCard3: null,
-		card1: null,
-		card2: null,
-		card3: null,
-	};
-
-	return (
-		<div className={homeContainer}>
-			<HeroSection title={homeData.title} subTitle={homeData.subTitle} />
-			<div className={divider} />
-			<ContentCardsSection homeData={homeData} />
-			<div className={divider} />
-			<CategoriesSection categories={categories} />
-			<div className={divider} />
-			<PostsSection
-				posts={posts}
-				isPreview={isPreview}
-				hasNextPage={hasNextPage}
-				isFetchingNextPage={isFetchingNextPage}
-				fetchNextPage={fetchNextPage}
-			/>
-			<div className={divider} />
-			<HighlightsSection />
-			<div className={divider} />
-			<ArchitectureSection badges={['React 19', 'TanStack Start', 'TypeScript', 'Sanity', 'Edge Friendly']} />
-			<div className={divider} />
-			<DevExpSection />
-			<div className={divider} />
-			<CTA />
-			<div className={divider} />
-		</div>
-	);
+  return (
+    <div className={homeContainer}>
+      <HeroSection title={homeData.title} subTitle={homeData.subTitle} />
+      <div className={divider} />
+      <ContentCardsSection homeData={homeData} />
+      <div className={divider} />
+    </div>
+  );
 };
 
 const HomePreview = withPreviewData(Home);
 const HomePublished = withPublishedData(Home);
 
 export function HomePage() {
-	const loaderData = Route.useLoaderData();
+  const loaderData = Route.useLoaderData();
 
-	// Use the reactive preview store instead of only the loader's isPreview
-	// This allows the component to switch when preview mode is detected client-side
-	const { isPreview: isPreviewFromStore } = useStore(previewStore);
+  // Use the reactive preview store instead of only the loader's isPreview
+  // This allows the component to switch when preview mode is detected client-side
+  const { isPreview: isPreviewFromStore } = useStore(previewStore);
 
-	const {
-		initial,
-		options,
-		query,
-		params,
-		sanity: { isPreview: isPreviewFromLoader },
-	} = loaderData;
+  const {
+    initial,
+    options,
+    query,
+    params,
+    sanity: { isPreview: isPreviewFromLoader },
+  } = loaderData;
 
-	// Use the store value (client-side reactive) with loader as fallback (SSR)
-	const isPreview = isPreviewFromStore || isPreviewFromLoader;
+  // Use the store value (client-side reactive) with loader as fallback (SSR)
+  const isPreview = isPreviewFromStore || isPreviewFromLoader;
 
-	// Note: We pass loader's isPreview to determine which wrapper to use,
-	// but the Home component itself reads from the store for reactive updates
-	return isPreview ? (
-		<HomePreview initial={initial} query={query} params={params} />
-	) : (
-		<HomePublished initial={initial?.data} tanstackQuery={homeQuery(options)} />
-	);
+  // Note: We pass loader's isPreview to determine which wrapper to use,
+  // but the Home component itself reads from the store for reactive updates
+  return isPreview ? (
+    <HomePreview initial={initial} query={query} params={params} />
+  ) : (
+    <HomePublished initial={initial?.data} tanstackQuery={homeQuery(options)} />
+  );
 }

--- a/apps/frontend/src/pages/Home/sections/HeroSection.tsx
+++ b/apps/frontend/src/pages/Home/sections/HeroSection.tsx
@@ -1,56 +1,22 @@
-import { SanityLogo } from '@/components/Logos/SanityLogo.tsx';
-import { TanStackLogo } from '@/components/Logos/TanStackLogo.tsx';
 import {
-	featureCard,
-	featureDescription,
-	featureGrid,
-	featureIcon,
-	featureTitle,
-	heroContent,
-	heroSection,
-	heroSubtitle,
-	heroTitle,
-	logo,
-	logoContainer,
-	logoSeparator,
-	logosRow,
-} from '../Home.css.ts';
+  heroContent,
+  heroSection,
+  heroSubtitle,
+  heroTitle,
+} from "../Home.css.ts";
 
 interface HeroSectionProps {
-	title?: string | null;
-	subTitle?: string | null;
+  title?: string | null;
+  subTitle?: string | null;
 }
 
-const FEATURES = [
-	{ icon: '⚡', title: 'Lightning Fast', desc: 'Server-side rendering with instant client-side navigation' },
-	{ icon: '👁️', title: 'Live Preview', desc: "Real-time content updates with Sanity's visual editing" },
-	{ icon: '🎨', title: 'Beautiful UI', desc: "Clean, modern design inspired by Apple's aesthetics" },
-	{ icon: '📱', title: 'Fully Responsive', desc: 'Perfect experience on any device, any screen size' },
-];
-
 export function HeroSection({ title, subTitle }: HeroSectionProps) {
-	return (
-		<section className={heroSection}>
-			<div className={heroContent}>
-				<h1 className={heroTitle}>{title}</h1>
-				{subTitle && <p className={heroSubtitle}>{subTitle}</p>}
-				<div className={logoContainer}>
-					<div className={logosRow}>
-						<TanStackLogo height={40} className={logo} />
-						<span className={logoSeparator}>×</span>
-						<SanityLogo height={40} className={logo} />
-					</div>
-				</div>
-				<div className={featureGrid}>
-					{FEATURES.map((f) => (
-						<div className={featureCard} key={f.title}>
-							<div className={featureIcon}>{f.icon}</div>
-							<h2 className={featureTitle}>{f.title}</h2>
-							<p className={featureDescription}>{f.desc}</p>
-						</div>
-					))}
-				</div>
-			</div>
-		</section>
-	);
+  return (
+    <section className={heroSection}>
+      <div className={heroContent}>
+        <h1 className={heroTitle}>{title}</h1>
+        {subTitle && <p className={heroSubtitle}>{subTitle}</p>}
+      </div>
+    </section>
+  );
 }


### PR DESCRIPTION
## Summary
Simplified the Home page layout by removing multiple sections and streamlining the Hero component for a cleaner demo experience.

## Changes
- **Home.tsx**: Removed multiple sections (Categories, Posts, Highlights, Architecture, DevExp, CTA) keeping only Hero and ContentCards sections
- **HeroSection.tsx**: Simplified by removing feature cards, logos, and related imports/unused CSS classes
- Cleaned up component structure and dependencies

## Reasoning
This refactoring creates a minimal, focused demo layout that highlights the core functionality without unnecessary complexity. The simplified structure makes it easier to understand and maintain while still demonstrating the key features of the TanStack Start + Sanity integration.

## Files Changed
- `apps/frontend/src/pages/Home/Home.tsx`
- `apps/frontend/src/pages/Home/sections/HeroSection.tsx`