### PR TITLE
feat: Add internal/external link handling for HomePage

### DIFF
--- a/apps/frontend/src/pages/Home/sections/ContentCardsSection.tsx
+++ b/apps/frontend/src/pages/Home/sections/ContentCardsSection.tsx
@@ -1,4 +1,5 @@
 import type { HomeDocument } from "@/types/home.ts";
+import { Link } from "@tanstack/react-router";
 import {
   buttonLink,
   cardPair,
@@ -39,11 +40,23 @@ export function ContentCardsSection({ homeData }: ContentCardsSectionProps) {
             <div className={contentCard}>
               {card1.links && card1.links.length > 0 && (
                 <div className={linkList}>
-                  {card1.links.map((link) => (
-                    <a key={link.url} href={link.url} className={simpleLink}>
-                      {link.label}
-                    </a>
-                  ))}
+                  {card1.links.map((link) =>
+                    link.isExternal ? (
+                      <a
+                        key={link.url}
+                        href={link.url}
+                        className={simpleLink}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        {link.label}
+                      </a>
+                    ) : (
+                      <Link key={link.url} to={link.url} className={simpleLink}>
+                        {link.label}
+                      </Link>
+                    ),
+                  )}
                 </div>
               )}
               {card1.text && <p className={cardText}>{card1.text}</p>}
@@ -85,9 +98,20 @@ export function ContentCardsSection({ homeData }: ContentCardsSectionProps) {
                 if (block._type === "buttonContent") {
                   return (
                     <div key={block.label} className={linkList}>
-                      <a href={block.url} className={buttonLink}>
-                        {block.label}
-                      </a>
+                      {block.isExternal ? (
+                        <a
+                          href={block.url}
+                          className={buttonLink}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        >
+                          {block.label}
+                        </a>
+                      ) : (
+                        <Link to={block.url} className={buttonLink}>
+                          {block.label}
+                        </Link>
+                      )}
                     </div>
                   );
                 }

--- a/apps/frontend/src/types/home.ts
+++ b/apps/frontend/src/types/home.ts
@@ -2,7 +2,8 @@ import { z } from 'zod';
 
 const linkZ = z.object({
 	label: z.string(),
-	url: z.string().url(),
+	isExternal: z.boolean().optional(),
+	url: z.string(),
 });
 
 export const homeZ = z.object({
@@ -30,7 +31,7 @@ export const homeZ = z.object({
 				.array(
 					z.discriminatedUnion('_type', [
 						z.object({ _type: z.literal('textContent'), text: z.string().nullable() }),
-						z.object({ _type: z.literal('buttonContent'), label: z.string(), url: z.string().url() }),
+						z.object({ _type: z.literal('buttonContent'), label: z.string(), isExternal: z.boolean().optional(), url: z.string() }),
 					]),
 				)
 				.nullable()

--- a/apps/studio/src/schemaTypes/documentTypes/home.ts
+++ b/apps/studio/src/schemaTypes/documentTypes/home.ts
@@ -53,7 +53,19 @@ export const home = defineType({
 							type: 'object',
 							fields: [
 								{ name: 'label', type: 'string', title: 'Label' },
-								{ name: 'url', type: 'url', title: 'URL' },
+								{
+									name: 'isExternal',
+									type: 'boolean',
+									title: 'External Link?',
+									description: 'Check this if the link goes to an external website',
+									initialValue: false,
+								},
+								{
+									name: 'url',
+									type: 'string',
+									title: 'URL',
+									description: 'For internal links use path like "/about". For external links use full URL like "https://example.com"',
+								},
 							],
 						},
 					],
@@ -88,7 +100,19 @@ export const home = defineType({
 							title: 'Button',
 							fields: [
 								{ name: 'label', type: 'string', title: 'Label' },
-								{ name: 'url', type: 'url', title: 'URL' },
+								{
+									name: 'isExternal',
+									type: 'boolean',
+									title: 'External Link?',
+									description: 'Check this if the link goes to an external website',
+									initialValue: false,
+								},
+								{
+									name: 'url',
+									type: 'string',
+									title: 'URL',
+									description: 'For internal links use path like "/about". For external links use full URL like "https://example.com"',
+								},
 							],
 						},
 					],

--- a/package-lock.json
+++ b/package-lock.json
@@ -4384,7 +4384,6 @@
 			"resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
 			"integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">= 20.19.0"
 			},
@@ -5250,7 +5249,6 @@
 			"resolved": "https://registry.npmjs.org/@portabletext/sanity-bridge/-/sanity-bridge-2.0.2.tgz",
 			"integrity": "sha512-LZhW/MWgS/3SRJ0yXkrYFWppRu0NqTktfoPceTTY/o4b8/sId0t9Aeb9XUtSvVP7UCsnvulxw4OP5+Hje4zpRQ==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@portabletext/schema": "^2.1.1",
 				"@sanity/schema": "^5.9.0",


### PR DESCRIPTION
## Summary

This PR adds support for distinguishing between internal app links and external URLs in the HomePage content cards, plus includes rich text improvements from the previous session.

## Changes

### Internal/External Link Handling

**Sanity Studio** (`apps/studio/src/schemaTypes/documentTypes/home.ts`)
- Added `isExternal` boolean checkbox to card1 links and card3 buttonContent
- Changed `url` field from `type: 'url'` to `type: 'string'` to allow internal paths like `/about`

**Frontend Types** (`apps/frontend/src/types/home.ts`)
- Added `isExternal` field to link schemas
- Updated URL validation to accept both internal paths and full URLs

**Frontend Component** (`apps/frontend/src/pages/Home/sections/ContentCardsSection.tsx`)
- Internal links use TanStack Router `<Link>` for client-side navigation
- External links use `<a>` with `target="_blank"` and `rel="noopener noreferrer"`

### Rich Text Improvements (from previous work)
- Category description now supports rich text (blockContent)
- Added PortableText rendering for Category pages
- Fixed mobile overflow for long URLs in PortableText content
- Added link color styling (`primaryAlt`) for links in PortableText

## Usage

In Sanity Studio:
- **Internal links**: Leave "External Link?" unchecked, enter path like `/about` or `/design`
- **External links**: Check "External Link?", enter full URL like `https://example.com`