### PR TITLE
feat: desktop max-width constraints for cards and headers

### DIFF
--- a/apps/frontend/src/pages/Contact/Contact.css.ts
+++ b/apps/frontend/src/pages/Contact/Contact.css.ts
@@ -12,8 +12,13 @@ export const container = style({
 });
 
 export const headerPill = style({
-	width: 300,
+	width: '100%',
+	maxWidth: '90%',
 	borderRadius: 12,
+	'@media': {
+		'screen and (min-width: 769px)': { maxWidth: '37%' },
+		'screen and (min-width: 2560px)': { maxWidth: '30%' },
+	},
 	background: '#ffffff',
 	boxShadow: '0px 4px 4px rgba(0, 0, 0, 0.25)',
 	paddingTop: 16,
@@ -48,8 +53,13 @@ export const headerTitle = style({
 });
 
 export const formCard = style({
-	width: 323,
+	width: '100%',
+	maxWidth: '90%',
 	borderRadius: 20,
+	'@media': {
+		'screen and (min-width: 769px)': { maxWidth: '50%' },
+		'screen and (min-width: 2560px)': { maxWidth: '40%' },
+	},
 	background: 'rgba(255, 255, 255, 0.92)',
 	border: '2px solid #000000',
 	boxShadow: '0px 4px 4px rgba(0, 0, 0, 0.25)',

--- a/apps/frontend/src/pages/Home/Home.css.ts
+++ b/apps/frontend/src/pages/Home/Home.css.ts
@@ -36,6 +36,10 @@ export const heroContent = style({
 	borderRadius: '1.25rem',
 	padding: '2.5rem 2rem',
 	boxShadow: vars.shadow.subtle,
+	maxWidth: '46rem',
+	marginLeft: 'auto',
+	marginRight: 'auto',
+	width: '100%',
 	selectors: {
 		'[data-theme="dark"] &': {
 			background: vars.color.surfaceElevated,

--- a/apps/frontend/src/pages/Home/sections/ContentCardsSection.css.ts
+++ b/apps/frontend/src/pages/Home/sections/ContentCardsSection.css.ts
@@ -24,13 +24,13 @@ export const contentCardsSection = style({
 export const cardRow = style({
 	display: 'grid',
 	gridTemplateColumns: 'repeat(1, 1fr)',
-	gap: '2.5rem',
+	gap: '4rem',
 });
 
 export const cardPair = style({
 	display: 'flex',
 	flexDirection: 'column',
-	gap: '1.5rem',
+	gap: '2.5rem',
 });
 
 export const headingCard = style({
@@ -44,6 +44,10 @@ export const headingCard = style({
 	border: `2px solid ${vars.color.borderSoft}`,
 	borderRadius: '1.25rem',
 	boxShadow: vars.shadow.subtle,
+	maxWidth: '33rem',
+	marginLeft: 'auto',
+	marginRight: 'auto',
+	width: '100%',
 	selectors: {
 		'[data-theme="dark"] &': {
 			border: '2px solid rgba(210 201 201 / 0.63)',
@@ -69,6 +73,10 @@ export const contentCard = style({
 	gap: '1.5rem',
 	boxShadow: vars.shadow.subtle,
 	transition: 'transform 0.3s ease, box-shadow 0.3s ease',
+	maxWidth: '44rem',
+	marginLeft: 'auto',
+	marginRight: 'auto',
+	width: '100%',
 	':hover': {
 		transform: 'translateY(-4px)',
 		boxShadow: vars.shadow.float,


### PR DESCRIPTION
## Summary

- Home hero card capped at `46rem`, centered with margin auto
- Home heading cards capped at `33rem`, content cards at `44rem` (matching Penpot Intro frame specs)
- Increased card row gap (`2.5rem` → `4rem`) and pair gap (`1.5rem` → `2.5rem`) for more vertical breathing room
- Contact page `headerPill` and `formCard` switched from fixed px widths to responsive max-widths:
  - `headerPill`: 90% mobile → 37% desktop → 30% 4K
  - `formCard`: 90% mobile → 50% desktop → 40% 4K

## Test plan

- [x] View `/` on desktop — hero card, heading cards, and content cards should be constrained and centered
- [x] View `/contact` on desktop — form card wider than header pill
- [x] View `/contact` on a 4K display — both cards narrower than desktop
- [x] Verify mobile layout is unaffected on both routes