### PR TITLE
fix: strip Sanity Stega zero-width characters from SEO meta tags

### DIFF
--- a/apps/frontend/src/lib/seo.ts
+++ b/apps/frontend/src/lib/seo.ts
@@ -2,6 +2,17 @@ import AppLogo from "../../public/web-app-manifest-512x512-v2.png?url";
 
 const basePath = import.meta.env.VITE_BASE_PATH || process.env.VITE_BASE_PATH;
 
+/**
+ * Strips Sanity Stega encoding (zero-width and invisible Unicode characters)
+ * from a string so it's clean for use in meta tags and SEO values.
+ */
+const stegaPattern =
+  /[\u200B-\u200F\u2028-\u202F\u2060-\u2063\uFEFF\uFFF9-\uFFFB]/g;
+
+function stripStega(value: string): string {
+  return value.replace(stegaPattern, "");
+}
+
 export const seo = ({
   title,
   description,
@@ -15,24 +26,28 @@ export const seo = ({
   keywords?: string | Array<string>;
   relativeUrl?: string;
 }) => {
+  const cleanTitle = stripStega(title);
+  const cleanDescription = description ? stripStega(description) : undefined;
   const absoluteUrl = relativeUrl ? `${basePath}${relativeUrl}` : undefined;
   const keywordsString = Array.isArray(keywords)
-    ? keywords.join(", ")
-    : keywords;
+    ? keywords.map(stripStega).join(", ")
+    : keywords
+      ? stripStega(keywords)
+      : undefined;
 
   return [
-    { title },
-    { name: "twitter:title", content: title },
-    { name: "og:title", content: title },
+    { title: cleanTitle },
+    { name: "twitter:title", content: cleanTitle },
+    { name: "og:title", content: cleanTitle },
     { name: "og:type", content: "website" },
     { name: "twitter:image", content: image },
     { name: "twitter:card", content: "summary_large_image" },
     { name: "og:image", content: image },
-    ...(description
+    ...(cleanDescription
       ? [
-          { name: "description", content: description },
-          { name: "twitter:description", content: description },
-          { name: "og:description", content: description },
+          { name: "description", content: cleanDescription },
+          { name: "twitter:description", content: cleanDescription },
+          { name: "og:description", content: cleanDescription },
         ]
       : []),
     ...(keywordsString ? [{ name: "keywords", content: keywordsString }] : []),


### PR DESCRIPTION
## Problem

Sanity's Stega encoding injects invisible zero-width Unicode characters into text fields for visual editing overlays. These were leaking into all SEO meta tags — \, \, \, \, and the standard \ — causing garbled or polluted social sharing previews.

Additionally, \, \, \, and \ were resolving to \ URLs because \ was not set (fixed separately by setting the env var).

## Fix

Added a \ helper in \ that removes characters in the Stega Unicode ranges before values are used in meta tags:

- U+200B–U+200F (zero-width space, non-joiner, etc.)
- U+2028–U+202F (line/paragraph separators, narrow no-break space)
- U+2060–U+2063 (word joiner, invisible characters)
- U+FEFF (BOM / zero-width no-break space)
- U+FFF9–U+FFFB (interlinear annotation characters)

Applied to \, \, and \ before they're inserted into any meta tags.

## Verified

Tested on \ — all meta tags now contain clean, human-readable text with no zero-width characters.