### PR TITLE
feat(frontend): render and cache water shader across routes

### DIFF
--- a/apps/frontend/src/components/GlobalLayout/GlobalLayout.css.ts
+++ b/apps/frontend/src/components/GlobalLayout/GlobalLayout.css.ts
@@ -1,5 +1,5 @@
-import { vars } from '@/styles/theme.css.ts';
 import { globalStyle, style } from '@vanilla-extract/css';
+import { vars } from '@/styles/theme.css.ts';
 
 globalStyle('html, body', { margin: 0 });
 
@@ -45,6 +45,11 @@ export const globalBackground = style({
 			backgroundPosition: 'top left',
 		},
 	},
+});
+
+export const contentLayer = style({
+	position: 'relative',
+	zIndex: 1,
 });
 
 globalStyle(`${globalBackground}::before`, {

--- a/apps/frontend/src/components/GlobalLayout/GlobalLayout.tsx
+++ b/apps/frontend/src/components/GlobalLayout/GlobalLayout.tsx
@@ -1,335 +1,360 @@
-import { ErrorBoundary } from "@/components/ErrorBoundary.tsx";
-import { ExitPreviewButton } from "@/components/ExitPreviewButton/ExitPreviewButton.tsx";
-import { Footer } from "@/components/Footer/Footer.tsx";
-import { FavIcons } from "@/components/GlobalLayout/FavIcons.tsx";
-import Header from "@/components/Header/Header.tsx";
-import { getCspNonce } from "@/functions/getCspNonce.ts";
-import TanStackQueryDevtools from "@/integrations/tanstack-query/devtools.tsx";
-import { PREVIEW_SESSION_NAME } from "@/lib/previewSession";
-import { Route } from "@/routes/__root.tsx";
-import {
-  previewStore,
-  setPreviewMode,
-  setPreviewPerspective,
-} from "@/stores/previewStore.ts";
-import { darkTheme, lightTheme } from "@/styles/theme.css.ts";
-import { globalBackground } from "@/components/GlobalLayout/GlobalLayout.css.ts";
-import { TanStackDevtools } from "@tanstack/react-devtools";
-import {
-  ClientOnly,
-  HeadContent,
-  Outlet,
-  Scripts,
-} from "@tanstack/react-router";
-import { TanStackRouterDevtoolsPanel } from "@tanstack/react-router-devtools";
-import { useStore } from "@tanstack/react-store";
-import { Suspense, lazy, useEffect, useState } from "react";
+import { TanStackDevtools } from '@tanstack/react-devtools';
+import { ClientOnly, HeadContent, Outlet, Scripts } from '@tanstack/react-router';
+import { TanStackRouterDevtoolsPanel } from '@tanstack/react-router-devtools';
+import { useStore } from '@tanstack/react-store';
+import { lazy, Suspense, useEffect, useState } from 'react';
+import { ErrorBoundary } from '@/components/ErrorBoundary.tsx';
+import { ExitPreviewButton } from '@/components/ExitPreviewButton/ExitPreviewButton.tsx';
+import { Footer } from '@/components/Footer/Footer.tsx';
+import { FavIcons } from '@/components/GlobalLayout/FavIcons.tsx';
+import { contentLayer, globalBackground } from '@/components/GlobalLayout/GlobalLayout.css.ts';
+import Header from '@/components/Header/Header.tsx';
+import { getCspNonce } from '@/functions/getCspNonce.ts';
+import TanStackQueryDevtools from '@/integrations/tanstack-query/devtools.tsx';
+import { PREVIEW_SESSION_NAME } from '@/lib/previewSession';
+import { Route } from '@/routes/__root.tsx';
+import { previewStore, setPreviewMode, setPreviewPerspective } from '@/stores/previewStore.ts';
+import { darkTheme, lightTheme } from '@/styles/theme.css.ts';
 
-const VisualEditing = lazy(() => import("@/sanity/VisualEditing.tsx"));
+const VisualEditing = lazy(() => import('@/sanity/VisualEditing.tsx'));
+
+const importWaterShader = () => import('@/components/WaterShader/WaterShader.tsx');
+let waterShaderModulePromise: ReturnType<typeof importWaterShader> | null = null;
+let webglSupport: boolean | null = null;
+
+const loadWaterShader = () => {
+	if (!waterShaderModulePromise) {
+		waterShaderModulePromise = importWaterShader();
+	}
+	return waterShaderModulePromise;
+};
+
+const hasWebGLSupport = () => {
+	if (webglSupport !== null) return webglSupport;
+	try {
+		const canvas = document.createElement('canvas');
+		webglSupport = !!(canvas.getContext('webgl2') || canvas.getContext('webgl'));
+		return webglSupport;
+	} catch {
+		webglSupport = false;
+		return false;
+	}
+};
+
+const WaterShader = lazy(loadWaterShader);
 
 export const GlobalLayout = () => {
-  const { sanity } = Route.useLoaderData();
-  const { isPreview, isDraftsPerspective } = useStore(
-    previewStore,
-    (state) => state,
-  );
-  const [isEmbeddedStudio, setIsEmbeddedStudio] = useState(false);
-  const cspNonce = getCspNonce();
+	const { sanity } = Route.useLoaderData();
+	const { isPreview, isDraftsPerspective } = useStore(previewStore, (state) => state);
+	const [isEmbeddedStudio, setIsEmbeddedStudio] = useState(false);
+	const [showShader, setShowShader] = useState(false);
+	const cspNonce = getCspNonce();
 
-  useEffect(() => {
-    // Script for setting the Sanity Studio URL
-    const sanityScript = document.createElement("script");
-    sanityScript.nonce = cspNonce;
-    sanityScript.text = `window.__SANITY_STUDIO_URL__=${JSON.stringify(
-      process.env.SANITY_STUDIO_URL ||
-        process.env.VITE_SANITY_STUDIO_URL ||
-        "http://localhost:3333",
-    )};`;
-    document.head.appendChild(sanityScript);
+	useEffect(() => {
+		// Script for setting the Sanity Studio URL
+		const sanityScript = document.createElement('script');
+		sanityScript.nonce = cspNonce;
+		sanityScript.text = `window.__SANITY_STUDIO_URL__=${JSON.stringify(
+			process.env.SANITY_STUDIO_URL || process.env.VITE_SANITY_STUDIO_URL || 'http://localhost:3333',
+		)};`;
+		document.head.appendChild(sanityScript);
 
-    // Script for early theme bootstrap
-    const themeScript = document.createElement("script");
-    themeScript.nonce = cspNonce;
-    themeScript.text = `(function(){try{var s=localStorage.getItem('theme');var m=window.matchMedia('(prefers-color-scheme:dark)').matches;var t=s||(m?'dark':'light');if(t==='dark'){document.documentElement.setAttribute('data-theme','dark');document.documentElement.classList.add('${darkTheme}');}else{document.documentElement.classList.add('${lightTheme}');}}catch(e){document.documentElement.classList.add('${lightTheme}');}})();`;
-    document.head.appendChild(themeScript);
+		// Script for early theme bootstrap
+		const themeScript = document.createElement('script');
+		themeScript.nonce = cspNonce;
+		themeScript.text = `(function(){try{var s=localStorage.getItem('theme');var m=window.matchMedia('(prefers-color-scheme:dark)').matches;var t=s||(m?'dark':'light');if(t==='dark'){document.documentElement.setAttribute('data-theme','dark');document.documentElement.classList.add('${darkTheme}');}else{document.documentElement.classList.add('${lightTheme}');}}catch(e){document.documentElement.classList.add('${lightTheme}');}})();`;
+		document.head.appendChild(themeScript);
 
-    return () => {
-      document.head.removeChild(sanityScript);
-      document.head.removeChild(themeScript);
-    };
-  }, [cspNonce]);
+		return () => {
+			document.head.removeChild(sanityScript);
+			document.head.removeChild(themeScript);
+		};
+	}, [cspNonce]);
 
-  useEffect(() => {
-    setPreviewMode(sanity.isPreview);
-  }, [sanity.isPreview]);
+	useEffect(() => {
+		setPreviewMode(sanity.isPreview);
+	}, [sanity.isPreview]);
 
-  // Re-check preview mode on client mount
-  // (handles case where request context is unavailable after redirects)
-  useEffect(() => {
-    if (typeof document !== "undefined") {
-      const hasCookie = document.cookie.includes(`${PREVIEW_SESSION_NAME}=`);
+	// Re-check preview mode on client mount
+	// (handles case where request context is unavailable after redirects)
+	useEffect(() => {
+		if (typeof document !== 'undefined') {
+			const hasCookie = document.cookie.includes(`${PREVIEW_SESSION_NAME}=`);
 
-      // Also check URL parameters for perspective (Sanity Studio sends this)
-      const urlParams = new URLSearchParams(window.location.search);
-      const perspectiveParam = urlParams.get("perspective");
-      const hasPerspectiveParam =
-        perspectiveParam === "previewDrafts" || perspectiveParam === "drafts";
+			// Also check URL parameters for perspective (Sanity Studio sends this)
+			const urlParams = new URLSearchParams(window.location.search);
+			const perspectiveParam = urlParams.get('perspective');
+			const hasPerspectiveParam = perspectiveParam === 'previewDrafts' || perspectiveParam === 'drafts';
 
-      const shouldBeInPreview = hasCookie || hasPerspectiveParam;
+			const shouldBeInPreview = hasCookie || hasPerspectiveParam;
 
-      if (shouldBeInPreview !== isPreview) {
-        setPreviewMode(shouldBeInPreview);
-      }
-    }
-  }, [isPreview]);
+			if (shouldBeInPreview !== isPreview) {
+				setPreviewMode(shouldBeInPreview);
+			}
+		}
+	}, [isPreview]);
 
-  // Check URL params for perspective and listen for Studio messages
-  useEffect(() => {
-    if (!isPreview) return;
+	// Check URL params for perspective and listen for Studio messages
+	useEffect(() => {
+		if (!isPreview) return;
 
-    const checkPerspective = () => {
-      const params = new URLSearchParams(window.location.search);
-      const perspective = params.get("perspective");
+		const checkPerspective = () => {
+			const params = new URLSearchParams(window.location.search);
+			const perspective = params.get('perspective');
 
-      // Sanity Studio sends perspective in URL params
-      if (perspective) {
-        const isDrafts =
-          perspective === "previewDrafts" || perspective === "drafts";
-        setPreviewPerspective(isDrafts);
-      }
-    };
+			// Sanity Studio sends perspective in URL params
+			if (perspective) {
+				const isDrafts = perspective === 'previewDrafts' || perspective === 'drafts';
+				setPreviewPerspective(isDrafts);
+			}
+		};
 
-    // Check on mount
-    checkPerspective();
+		// Check on mount
+		checkPerspective();
 
-    // Listen for messages from Sanity Studio (for perspective changes)
-    const handleMessage = (event: MessageEvent) => {
-      if (event.data && typeof event.data === "object") {
-        // Check for perspective change messages from Sanity Presentation Tool
-        if (
-          event.data.type === "presentation/perspective" &&
-          event.data.data?.perspective
-        ) {
-          const perspective = event.data.data.perspective;
-          const isDrafts =
-            perspective === "previewDrafts" || perspective === "drafts";
-          setPreviewPerspective(isDrafts);
-        }
-      }
-    };
+		// Listen for messages from Sanity Studio (for perspective changes)
+		const handleMessage = (event: MessageEvent) => {
+			if (event.data && typeof event.data === 'object') {
+				// Check for perspective change messages from Sanity Presentation Tool
+				if (event.data.type === 'presentation/perspective' && event.data.data?.perspective) {
+					const perspective = event.data.data.perspective;
+					const isDrafts = perspective === 'previewDrafts' || perspective === 'drafts';
+					setPreviewPerspective(isDrafts);
+				}
+			}
+		};
 
-    // Listen for URL changes (when Studio navigates)
-    const handlePopState = () => {
-      checkPerspective();
-    };
+		// Listen for URL changes (when Studio navigates)
+		const handlePopState = () => {
+			checkPerspective();
+		};
 
-    window.addEventListener("message", handleMessage);
-    window.addEventListener("popstate", handlePopState);
+		window.addEventListener('message', handleMessage);
+		window.addEventListener('popstate', handlePopState);
 
-    return () => {
-      window.removeEventListener("message", handleMessage);
-      window.removeEventListener("popstate", handlePopState);
-    };
-  }, [isPreview]);
+		return () => {
+			window.removeEventListener('message', handleMessage);
+			window.removeEventListener('popstate', handlePopState);
+		};
+	}, [isPreview]);
 
-  useEffect(() => {
-    if (typeof window !== "undefined") {
-      // Check if we are running in an iframe (Sanity Studio preview pane)
-      const embedded = window.self !== window.top;
-      setIsEmbeddedStudio(embedded);
-    }
-  }, []);
+	useEffect(() => {
+		if (typeof window !== 'undefined') {
+			// Check if we are running in an iframe (Sanity Studio preview pane)
+			const embedded = window.self !== window.top;
+			setIsEmbeddedStudio(embedded);
+		}
+	}, []);
 
-  // Preserve vanilla-extract and other critical styles across route navigation
-  // This is a workaround for: https://github.com/vercel/next.js/issues/53858
-  useEffect(() => {
-    // Keep a copy of vanilla-extract and critical styles
-    const criticalStyles = new Map<string, HTMLStyleElement>();
+	// Defer shader bundle until after first paint and only when WebGL is available.
+	useEffect(() => {
+		if (!hasWebGLSupport()) return;
 
-    // Store copies of all vanilla-extract styles
-    const markAndStoreCriticalStyles = () => {
-      const styles = document.querySelectorAll(
-        "style[data-vanilla-extract], style[data-tailwind]",
-      );
-      styles.forEach((style, index) => {
-        const key = `critical-style-${index}`;
-        style.setAttribute("data-critical", "true");
-        style.setAttribute("data-style-key", key);
-        criticalStyles.set(key, style.cloneNode(true) as HTMLStyleElement);
-      });
-    };
+		// Warm the code-split chunk once and let route transitions reuse it.
+		const preloadTimer = window.setTimeout(() => {
+			void loadWaterShader();
+		}, 0);
 
-    markAndStoreCriticalStyles();
+		setShowShader(true);
 
-    const observer = new MutationObserver(() => {
-      // Periodically check if critical styles are missing and re-add them
-      const currentStyles = new Set<string>();
-      document.querySelectorAll("style[data-style-key]").forEach((style) => {
-        const key = style.getAttribute("data-style-key");
-        if (key) currentStyles.add(key);
-      });
+		return () => {
+			window.clearTimeout(preloadTimer);
+		};
+	}, []);
 
-      // Re-add any missing critical styles
-      criticalStyles.forEach((styleEl, key) => {
-        if (!currentStyles.has(key)) {
-          const clone = styleEl.cloneNode(true) as HTMLStyleElement;
-          clone.setAttribute("data-style-key", key);
-          clone.setAttribute("data-critical", "true");
-          document.head.appendChild(clone);
-        }
-      });
-    });
+	// Preserve vanilla-extract and other critical styles across route navigation
+	// This is a workaround for: https://github.com/vercel/next.js/issues/53858
+	useEffect(() => {
+		// Keep a copy of vanilla-extract and critical styles
+		const criticalStyles = new Map<string, HTMLStyleElement>();
 
-    observer.observe(document.head, {
-      childList: true,
-      subtree: false,
-    });
+		// Store copies of all vanilla-extract styles
+		const markAndStoreCriticalStyles = () => {
+			const styles = document.querySelectorAll('style[data-vanilla-extract], style[data-tailwind]');
+			styles.forEach((style, index) => {
+				const key = `critical-style-${index}`;
+				style.setAttribute('data-critical', 'true');
+				style.setAttribute('data-style-key', key);
+				criticalStyles.set(key, style.cloneNode(true) as HTMLStyleElement);
+			});
+		};
 
-    return () => {
-      observer.disconnect();
-    };
-  }, []);
+		markAndStoreCriticalStyles();
 
-  return (
-    <html lang="en">
-      <head>
-        <title>SanTan Starter</title>
-        <meta name="viewport" content="width=device-width,initial-scale=1" />
-        {/* Router-managed head (injects global stylesheet, meta, etc.) */}
-        <HeadContent />
-        <FavIcons />
-      </head>
-      <body>
-        <div className={globalBackground} aria-hidden="true" />
-        <a
-          href="#app-root"
-          aria-label="Skip to main content"
-          style={{
-            position: "absolute",
-            left: "-999px",
-            top: "-999px",
-            background: "#000",
-            color: "#fff",
-            padding: "8px 12px",
-            borderRadius: 4,
-            transform: "translateY(-8px)",
-          }}
-          onFocus={(e) => {
-            e.currentTarget.style.left = "12px";
-            e.currentTarget.style.top = "12px";
-          }}
-          onBlur={(e) => {
-            e.currentTarget.style.left = "-999px";
-            e.currentTarget.style.top = "-999px";
-          }}
-        >
-          Skip to content
-        </a>
-        <ErrorBoundary>
-          <Header />
-          <main id="app-root">
-            <Outlet />
-          </main>
-          <Footer />
-          <TanStackDevtools
-            config={{ position: "bottom-right" }}
-            plugins={[
-              {
-                name: "Tanstack Router",
-                render: <TanStackRouterDevtoolsPanel />,
-              },
-              TanStackQueryDevtools,
-            ]}
-          />
-          <Scripts />
-          <ClientOnly>
-            {isPreview && isEmbeddedStudio && (
-              <>
-                {isDraftsPerspective ? (
-                  <div
-                    role="status"
-                    aria-live="polite"
-                    style={{
-                      position: "fixed",
-                      bottom: "10px",
-                      left: "10px",
-                      background: "rgba(255,165,0,0.65)",
-                      color: "#111",
-                      padding: "8px 12px",
-                      borderRadius: "6px",
-                      fontSize: "12px",
-                      fontWeight: "600",
-                      zIndex: 999999,
-                      boxShadow: "0 2px 8px rgba(0,0,0,0.25)",
-                      backdropFilter: "blur(6px)",
-                      border: "1px solid rgba(255,255,255,0.3)",
-                      letterSpacing: "0.5px",
-                      pointerEvents: "none",
-                      display: "flex",
-                      alignItems: "center",
-                      gap: "6px",
-                    }}
-                  >
-                    <span
-                      aria-hidden
-                      style={{
-                        width: 8,
-                        height: 8,
-                        borderRadius: "50%",
-                        background: "#ff8c00",
-                        boxShadow: "0 0 0 2px rgba(255,255,255,0.4)",
-                      }}
-                    />
-                    PREVIEW MODE (Drafts)
-                  </div>
-                ) : (
-                  <div
-                    role="status"
-                    aria-live="polite"
-                    style={{
-                      position: "fixed",
-                      bottom: "10px",
-                      left: "10px",
-                      background: "rgba(80,220,120,0.55)",
-                      color: "#07240f",
-                      padding: "8px 12px",
-                      borderRadius: "6px",
-                      fontSize: "12px",
-                      fontWeight: "600",
-                      zIndex: 999999,
-                      boxShadow: "0 2px 8px rgba(0,0,0,0.25)",
-                      backdropFilter: "blur(6px)",
-                      border: "1px solid rgba(255,255,255,0.3)",
-                      letterSpacing: "0.5px",
-                      pointerEvents: "none",
-                      display: "flex",
-                      alignItems: "center",
-                      gap: "6px",
-                    }}
-                  >
-                    <span
-                      aria-hidden
-                      style={{
-                        width: 8,
-                        height: 8,
-                        borderRadius: "50%",
-                        background: "#2bbf65",
-                        boxShadow: "0 0 0 2px rgba(255,255,255,0.4)",
-                      }}
-                    />
-                    PREVIEW MODE (Published)
-                  </div>
-                )}
-                <Suspense fallback={null}>
-                  <VisualEditing />
-                </Suspense>
-              </>
-            )}
-            {/* Exit Preview button - only shown when preview cookie is active outside the Studio iframe */}
-            <ExitPreviewButton />
-          </ClientOnly>
-        </ErrorBoundary>
-      </body>
-    </html>
-  );
+		const observer = new MutationObserver(() => {
+			// Periodically check if critical styles are missing and re-add them
+			const currentStyles = new Set<string>();
+			document.querySelectorAll('style[data-style-key]').forEach((style) => {
+				const key = style.getAttribute('data-style-key');
+				if (key) currentStyles.add(key);
+			});
+
+			// Re-add any missing critical styles
+			criticalStyles.forEach((styleEl, key) => {
+				if (!currentStyles.has(key)) {
+					const clone = styleEl.cloneNode(true) as HTMLStyleElement;
+					clone.setAttribute('data-style-key', key);
+					clone.setAttribute('data-critical', 'true');
+					document.head.appendChild(clone);
+				}
+			});
+		});
+
+		observer.observe(document.head, {
+			childList: true,
+			subtree: false,
+		});
+
+		return () => {
+			observer.disconnect();
+		};
+	}, []);
+
+	return (
+		<html lang="en">
+			<head>
+				<title>SanTan Starter</title>
+				<meta name="viewport" content="width=device-width,initial-scale=1" />
+				{/* Router-managed head (injects global stylesheet, meta, etc.) */}
+				<HeadContent />
+				<FavIcons />
+			</head>
+			<body>
+				<div className={globalBackground} aria-hidden="true" />
+				{showShader && (
+					<Suspense fallback={null}>
+						<WaterShader />
+					</Suspense>
+				)}
+				<a
+					href="#app-root"
+					aria-label="Skip to main content"
+					style={{
+						position: 'absolute',
+						left: '-999px',
+						top: '-999px',
+						background: '#000',
+						color: '#fff',
+						padding: '8px 12px',
+						borderRadius: 4,
+						transform: 'translateY(-8px)',
+					}}
+					onFocus={(e) => {
+						e.currentTarget.style.left = '12px';
+						e.currentTarget.style.top = '12px';
+					}}
+					onBlur={(e) => {
+						e.currentTarget.style.left = '-999px';
+						e.currentTarget.style.top = '-999px';
+					}}
+				>
+					Skip to content
+				</a>
+				<ErrorBoundary>
+					<Header />
+					<main id="app-root" className={contentLayer}>
+						<Outlet />
+					</main>
+					<Footer />
+					<TanStackDevtools
+						config={{ position: 'bottom-right' }}
+						plugins={[
+							{
+								name: 'Tanstack Router',
+								render: <TanStackRouterDevtoolsPanel />,
+							},
+							TanStackQueryDevtools,
+						]}
+					/>
+					<Scripts />
+					<ClientOnly>
+						{isPreview && isEmbeddedStudio && (
+							<>
+								{isDraftsPerspective ? (
+									<div
+										role="status"
+										aria-live="polite"
+										style={{
+											position: 'fixed',
+											bottom: '10px',
+											left: '10px',
+											background: 'rgba(255,165,0,0.65)',
+											color: '#111',
+											padding: '8px 12px',
+											borderRadius: '6px',
+											fontSize: '12px',
+											fontWeight: '600',
+											zIndex: 999999,
+											boxShadow: '0 2px 8px rgba(0,0,0,0.25)',
+											backdropFilter: 'blur(6px)',
+											border: '1px solid rgba(255,255,255,0.3)',
+											letterSpacing: '0.5px',
+											pointerEvents: 'none',
+											display: 'flex',
+											alignItems: 'center',
+											gap: '6px',
+										}}
+									>
+										<span
+											aria-hidden
+											style={{
+												width: 8,
+												height: 8,
+												borderRadius: '50%',
+												background: '#ff8c00',
+												boxShadow: '0 0 0 2px rgba(255,255,255,0.4)',
+											}}
+										/>
+										PREVIEW MODE (Drafts)
+									</div>
+								) : (
+									<div
+										role="status"
+										aria-live="polite"
+										style={{
+											position: 'fixed',
+											bottom: '10px',
+											left: '10px',
+											background: 'rgba(80,220,120,0.55)',
+											color: '#07240f',
+											padding: '8px 12px',
+											borderRadius: '6px',
+											fontSize: '12px',
+											fontWeight: '600',
+											zIndex: 999999,
+											boxShadow: '0 2px 8px rgba(0,0,0,0.25)',
+											backdropFilter: 'blur(6px)',
+											border: '1px solid rgba(255,255,255,0.3)',
+											letterSpacing: '0.5px',
+											pointerEvents: 'none',
+											display: 'flex',
+											alignItems: 'center',
+											gap: '6px',
+										}}
+									>
+										<span
+											aria-hidden
+											style={{
+												width: 8,
+												height: 8,
+												borderRadius: '50%',
+												background: '#2bbf65',
+												boxShadow: '0 0 0 2px rgba(255,255,255,0.4)',
+											}}
+										/>
+										PREVIEW MODE (Published)
+									</div>
+								)}
+								<Suspense fallback={null}>
+									<VisualEditing />
+								</Suspense>
+							</>
+						)}
+						{/* Exit Preview button - only shown when preview cookie is active outside the Studio iframe */}
+						<ExitPreviewButton />
+					</ClientOnly>
+				</ErrorBoundary>
+			</body>
+		</html>
+	);
 };

--- a/apps/frontend/src/pages/Home/Home.tsx
+++ b/apps/frontend/src/pages/Home/Home.tsx
@@ -1,106 +1,78 @@
-import type { PreviewableComponent } from "@/components/PreviewWrapper.tsx";
-import { withPublishedData } from "@/components/withDocument.tsx";
-import { Route } from "@/routes/index.tsx";
-import { homeQuery } from "@/sanity/queries/homeQuery.ts";
-import { previewStore } from "@/stores/previewStore.ts";
-import type { PageProps } from "@/types/PageProps.ts";
-import type { HomeDocument } from "@/types/home.ts";
-import { useStore } from "@tanstack/react-store";
-import { Suspense, lazy, useEffect, useState } from "react";
+import { useStore } from '@tanstack/react-store';
+import { lazy, Suspense } from 'react';
+import type { PreviewableComponent } from '@/components/PreviewWrapper.tsx';
+import { SocialLinks } from '@/components/SocialLinks/SocialLinks.tsx';
+import { withPublishedData } from '@/components/withDocument.tsx';
+import { Route } from '@/routes/index.tsx';
+import { homeQuery } from '@/sanity/queries/homeQuery.ts';
+import { previewStore } from '@/stores/previewStore.ts';
+import type { HomeDocument } from '@/types/home.ts';
+import type { PageProps } from '@/types/PageProps.ts';
 // Styles
-import { divider, homeContainer, socialLinksRow } from "./Home.css.ts";
+import { divider, homeContainer, socialLinksRow } from './Home.css.ts';
+import { ContentCardsSection } from './sections/ContentCardsSection.tsx';
+import { HeroSection } from './sections/HeroSection.tsx';
 
-import { SocialLinks } from "@/components/SocialLinks/SocialLinks.tsx";
-import { ContentCardsSection } from "./sections/ContentCardsSection.tsx";
-import { HeroSection } from "./sections/HeroSection.tsx";
-
-const PreviewWrapper = lazy(() => import("@/components/PreviewWrapper.tsx"));
-const WaterShader = lazy(() => import("@/components/WaterShader/WaterShader.tsx"));
+const PreviewWrapper = lazy(() => import('@/components/PreviewWrapper.tsx'));
 
 type HomePagePayload = {
-  homeData: HomeDocument;
+	homeData: HomeDocument;
 };
 
 const Home = ({ data }: PageProps<HomePagePayload>) => {
-  const homeData = data?.homeData ?? {
-    title: null,
-    subTitle: null,
-    headingCard1: null,
-    headingCard2: null,
-    headingCard3: null,
-    card1: null,
-    card2: null,
-    card3: null,
-  };
+	const homeData = data?.homeData ?? {
+		title: null,
+		subTitle: null,
+		headingCard1: null,
+		headingCard2: null,
+		headingCard3: null,
+		card1: null,
+		card2: null,
+		card3: null,
+	};
 
-  return (
-    <div className={homeContainer}>
-      <HeroSection title={homeData.title} subTitle={homeData.subTitle} />
-      <div className={divider} />
-      <ContentCardsSection homeData={homeData} />
-      <div className={divider} />
-      <div className={socialLinksRow}>
-        <SocialLinks />
-      </div>
-    </div>
-  );
+	return (
+		<div className={homeContainer}>
+			<HeroSection title={homeData.title} subTitle={homeData.subTitle} />
+			<div className={divider} />
+			<ContentCardsSection homeData={homeData} />
+			<div className={divider} />
+			<div className={socialLinksRow}>
+				<SocialLinks />
+			</div>
+		</div>
+	);
 };
 
 const HomePublished = withPublishedData(Home);
 
 export function HomePage() {
-  const loaderData = Route.useLoaderData();
+	const loaderData = Route.useLoaderData();
 
-  // Use the reactive preview store instead of only the loader's isPreview
-  // This allows the component to switch when preview mode is detected client-side
-  const { isPreview: isPreviewFromStore } = useStore(
-    previewStore,
-    (state) => state,
-  );
+	// Use the reactive preview store instead of only the loader's isPreview
+	// This allows the component to switch when preview mode is detected client-side
+	const { isPreview: isPreviewFromStore } = useStore(previewStore, (state) => state);
 
-  const {
-    initial,
-    options,
-    query,
-    params,
-    sanity: { isPreview: isPreviewFromLoader },
-  } = loaderData;
+	const {
+		initial,
+		options,
+		query,
+		params,
+		sanity: { isPreview: isPreviewFromLoader },
+	} = loaderData;
 
-  // Use the store value (client-side reactive) with loader as fallback (SSR)
-  const isPreview = isPreviewFromStore || isPreviewFromLoader;
+	// Use the store value (client-side reactive) with loader as fallback (SSR)
+	const isPreview = isPreviewFromStore || isPreviewFromLoader;
 
-  // Defer shader load until after first paint to protect Lighthouse scores.
-  // Also check for WebGL support before loading the shader bundle at all.
-  const [showShader, setShowShader] = useState(false);
-  useEffect(() => {
-    try {
-      const canvas = document.createElement("canvas");
-      const gl = canvas.getContext("webgl2") || canvas.getContext("webgl");
-      if (gl) setShowShader(true);
-    } catch {
-      // No WebGL — skip shader entirely
-    }
-  }, []);
-
-  return (
-    <>
-      {showShader && (
-        <Suspense fallback={null}>
-          <WaterShader />
-        </Suspense>
-      )}
-      {isPreview ? (
-        <Suspense fallback={null}>
-          <PreviewWrapper
-            query={query}
-            params={params}
-            initial={initial}
-            component={Home as PreviewableComponent}
-          />
-        </Suspense>
-      ) : (
-        <HomePublished initial={initial?.data} tanstackQuery={homeQuery(options)} />
-      )}
-    </>
-  );
+	return (
+		<>
+			{isPreview ? (
+				<Suspense fallback={null}>
+					<PreviewWrapper query={query} params={params} initial={initial} component={Home as PreviewableComponent} />
+				</Suspense>
+			) : (
+				<HomePublished initial={initial?.data} tanstackQuery={homeQuery(options)} />
+			)}
+		</>
+	);
 }


### PR DESCRIPTION
## Summary
- move WaterShader mounting from the home route into GlobalLayout so it appears across routes
- add one-time shader module preload/caching in root layout to avoid reloading on route changes
- keep content layered above shader via a shared layout z-index style

## Testing
- npx biome check apps/frontend/src/components/GlobalLayout/GlobalLayout.tsx apps/frontend/src/components/GlobalLayout/GlobalLayout.css.ts apps/frontend/src/pages/Home/Home.tsx
- npm run type-check --workspace=@santan/frontend (fails due existing unrelated vite.config.ts typing issue)