### PR TITLE
feat: sync contact form submissions into Sanity CMS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ blob-report/
 .env.*
 !.env.example
 !**/.env.example
+.env*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,7 @@ VITE_SANITY_DATASET=production
 VITE_SANITY_API_VERSION=2024-01-01
 SESSION_SECRET=
 SANITY_READ_TOKEN=     # Required for preview mode
+SANITY_WRITE_TOKEN=    # Server-only; create contactSubmission docs on form submit
 DATABASE_URL=          # Neon Postgres (contact form)
 ZOHO_SMTP_USER=        # Zoho Mail SMTP for auto-replies
 ZOHO_SMTP_PASS=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,6 +108,7 @@ VITE_SANITY_DATASET=production
 VITE_SANITY_API_VERSION=2024-01-01
 SESSION_SECRET=
 SANITY_READ_TOKEN=     # Required for preview mode
+SANITY_WRITE_TOKEN=    # Server-only; create contactSubmission docs on form submit
 DATABASE_URL=          # Neon Postgres (contact form)
 ZOHO_SMTP_USER=        # Zoho Mail SMTP for auto-replies
 ZOHO_SMTP_PASS=

--- a/apps/frontend/.env.example
+++ b/apps/frontend/.env.example
@@ -9,6 +9,11 @@ VITE_SANITY_API_VERSION=2024-01-01
 SESSION_SECRET=your_session_secret_here
 SANITY_READ_TOKEN=your_sanity_read_token
 
+# Sanity write token (server-only) — create contactSubmission docs on form submit
+# Create at https://www.sanity.io/manage → API → Tokens (Editor or custom with create on contactSubmission)
+# Never expose this to the client (no VITE_ prefix)
+SANITY_WRITE_TOKEN=your_sanity_write_token
+
 # Neon (contact form submissions)
 # Create a free project at https://console.neon.tech and paste the pooled connection string
 DATABASE_URL=postgresql://user:password@ep-xxx.us-east-2.aws.neon.tech/neondb?sslmode=require

--- a/apps/frontend/src/lib/env.ts
+++ b/apps/frontend/src/lib/env.ts
@@ -19,6 +19,8 @@ const serverEnvSchema = z.object({
 	SANITY_API_VERSION: z.string().optional(), // Allow fallback
 	SANITY_STUDIO_URL: z.string().optional(),
 	SANITY_READ_TOKEN: z.string().optional(),
+	/** Server-only write token for creating contactSubmission docs (never expose to client). */
+	SANITY_WRITE_TOKEN: z.string().optional(),
 	SANITY_SESSION_SECRET: z.string().optional(),
 	NODE_ENV: z.enum(['development', 'production', 'test']).default('development'),
 });
@@ -29,6 +31,7 @@ export type Env = {
 	SANITY_API_VERSION: string;
 	SANITY_STUDIO_URL?: string;
 	SANITY_READ_TOKEN?: string;
+	SANITY_WRITE_TOKEN?: string;
 	SANITY_SESSION_SECRET: string;
 	NODE_ENV: 'development' | 'production' | 'test';
 };
@@ -51,6 +54,7 @@ function validateEnv(): Env {
 				SANITY_API_VERSION: apiVersion || '2025-12-04',
 				SANITY_STUDIO_URL: studioUrl,
 				SANITY_READ_TOKEN: serverVars.SANITY_READ_TOKEN,
+				SANITY_WRITE_TOKEN: serverVars.SANITY_WRITE_TOKEN,
 				SANITY_SESSION_SECRET: serverVars.SANITY_SESSION_SECRET || '',
 				NODE_ENV: serverVars.NODE_ENV,
 			};
@@ -75,6 +79,7 @@ function validateEnv(): Env {
 			SANITY_API_VERSION: apiVersion || '2025-12-04',
 			SANITY_STUDIO_URL: clientVars.VITE_SANITY_STUDIO_URL,
 			SANITY_READ_TOKEN: undefined,
+			SANITY_WRITE_TOKEN: undefined,
 			SANITY_SESSION_SECRET: '', // Not available on client
 			NODE_ENV: (import.meta.env.MODE || 'production') as 'development' | 'production' | 'test',
 		};
@@ -90,6 +95,7 @@ function validateEnv(): Env {
 				SANITY_API_VERSION: '2025-12-04',
 				SANITY_STUDIO_URL: undefined,
 				SANITY_READ_TOKEN: undefined,
+				SANITY_WRITE_TOKEN: undefined,
 				SANITY_SESSION_SECRET: '',
 				NODE_ENV: 'production',
 			};

--- a/apps/frontend/src/server/contact/__tests__/handleContactSubmission.test.ts
+++ b/apps/frontend/src/server/contact/__tests__/handleContactSubmission.test.ts
@@ -8,12 +8,18 @@ vi.mock('@/server/email/zohoSmtp.ts', () => ({
 	sendContactReplyEmail: vi.fn(),
 }));
 
+vi.mock('@/server/contact/syncContactSubmissionToSanity.ts', () => ({
+	syncContactSubmissionToSanity: vi.fn(),
+}));
+
 import { insertContactSubmission } from '@/db/client.ts';
+import { syncContactSubmissionToSanity } from '@/server/contact/syncContactSubmissionToSanity.ts';
 import { sendContactReplyEmail } from '@/server/email/zohoSmtp.ts';
 import { handleContactSubmission } from '../handleContactSubmission.ts';
 
 const insertMock = vi.mocked(insertContactSubmission);
 const emailMock = vi.mocked(sendContactReplyEmail);
+const sanityMock = vi.mocked(syncContactSubmissionToSanity);
 
 describe('handleContactSubmission', () => {
 	beforeEach(() => {
@@ -28,6 +34,8 @@ describe('handleContactSubmission', () => {
 		additionalInfo: 'Please review my site',
 	};
 
+	const createdAt = '2026-04-01T12:00:00.000Z';
+
 	it('returns field errors for invalid input without writing to DB', async () => {
 		const result = await handleContactSubmission({ firstName: '' });
 		expect(result.success).toBe(false);
@@ -36,9 +44,10 @@ describe('handleContactSubmission', () => {
 		}
 		expect(insertMock).not.toHaveBeenCalled();
 		expect(emailMock).not.toHaveBeenCalled();
+		expect(sanityMock).not.toHaveBeenCalled();
 	});
 
-	it('stores submission and sends email on success', async () => {
+	it('stores submission, syncs to Sanity, and sends email on success', async () => {
 		insertMock.mockResolvedValue({
 			id: 'uuid-1',
 			first_name: 'Jane',
@@ -46,8 +55,9 @@ describe('handleContactSubmission', () => {
 			email: 'jane@example.com',
 			reason_for_message: 'Website audit',
 			additional_info: 'Please review my site',
-			created_at: new Date().toISOString(),
+			created_at: createdAt,
 		});
+		sanityMock.mockResolvedValue({ id: 'contactSubmission-uuid-1', created: true });
 		emailMock.mockResolvedValue(undefined);
 
 		const result = await handleContactSubmission(valid);
@@ -59,6 +69,15 @@ describe('handleContactSubmission', () => {
 			email: 'jane@example.com',
 			reasonForMessage: 'Website audit',
 			additionalInfo: 'Please review my site',
+		});
+		expect(sanityMock).toHaveBeenCalledWith({
+			neonId: 'uuid-1',
+			firstName: 'Jane',
+			lastName: 'Doe',
+			email: 'jane@example.com',
+			reasonForMessage: 'Website audit',
+			additionalInfo: 'Please review my site',
+			submittedAt: createdAt,
 		});
 		expect(emailMock).toHaveBeenCalledWith({
 			to: 'jane@example.com',
@@ -77,6 +96,7 @@ describe('handleContactSubmission', () => {
 		if (!result.success) {
 			expect(result.error).toMatch(/Unable to save/i);
 		}
+		expect(sanityMock).not.toHaveBeenCalled();
 		expect(emailMock).not.toHaveBeenCalled();
 	});
 
@@ -88,13 +108,35 @@ describe('handleContactSubmission', () => {
 			email: 'jane@example.com',
 			reason_for_message: 'Website audit',
 			additional_info: null,
-			created_at: new Date().toISOString(),
+			created_at: createdAt,
 		});
+		sanityMock.mockResolvedValue({ id: 'contactSubmission-uuid-2', created: true });
 		emailMock.mockRejectedValue(new Error('smtp down'));
 
 		const result = await handleContactSubmission(valid);
 
 		expect(result).toEqual({ success: true, id: 'uuid-2' });
+		expect(emailMock).toHaveBeenCalled();
+		expect(sanityMock).toHaveBeenCalled();
+	});
+
+	it('still succeeds when Sanity sync fails after DB write', async () => {
+		insertMock.mockResolvedValue({
+			id: 'uuid-3',
+			first_name: 'Jane',
+			last_name: 'Doe',
+			email: 'jane@example.com',
+			reason_for_message: 'Website audit',
+			additional_info: null,
+			created_at: createdAt,
+		});
+		sanityMock.mockRejectedValue(new Error('sanity down'));
+		emailMock.mockResolvedValue(undefined);
+
+		const result = await handleContactSubmission(valid);
+
+		expect(result).toEqual({ success: true, id: 'uuid-3' });
+		expect(sanityMock).toHaveBeenCalled();
 		expect(emailMock).toHaveBeenCalled();
 	});
 });

--- a/apps/frontend/src/server/contact/__tests__/syncContactSubmissionToSanity.test.ts
+++ b/apps/frontend/src/server/contact/__tests__/syncContactSubmissionToSanity.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const createIfNotExists = vi.fn();
+const createClient = vi.fn((_config?: unknown) => ({ createIfNotExists }));
+
+vi.mock('@sanity/client', () => ({
+	createClient: (config: unknown) => createClient(config),
+}));
+
+vi.mock('@/sanity/projectDetails.ts', () => ({
+	projectId: 'test-project',
+	dataset: 'production',
+	apiVersion: '2024-01-01',
+}));
+
+describe('syncContactSubmissionToSanity', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.resetModules();
+		delete process.env.SANITY_WRITE_TOKEN;
+	});
+
+	const input = {
+		neonId: 'abc-123',
+		firstName: 'Jane',
+		lastName: 'Doe',
+		email: 'jane@example.com',
+		reasonForMessage: 'Hello',
+		additionalInfo: 'More info',
+		submittedAt: '2026-04-01T12:00:00.000Z',
+	};
+
+	it('returns null and does not call Sanity when write token is missing', async () => {
+		const { syncContactSubmissionToSanity } = await import('../syncContactSubmissionToSanity.ts');
+		const result = await syncContactSubmissionToSanity(input);
+		expect(result).toBeNull();
+		expect(createClient).not.toHaveBeenCalled();
+	});
+
+	it('creates a document with deterministic id when token is set', async () => {
+		process.env.SANITY_WRITE_TOKEN = 'write-token';
+		createIfNotExists.mockResolvedValue({ _id: 'contactSubmission-abc-123' });
+
+		const { syncContactSubmissionToSanity, contactSubmissionDocumentId } = await import(
+			'../syncContactSubmissionToSanity.ts'
+		);
+
+		const result = await syncContactSubmissionToSanity(input);
+
+		expect(contactSubmissionDocumentId('abc-123')).toBe('contactSubmission-abc-123');
+		expect(createClient).toHaveBeenCalledWith(
+			expect.objectContaining({
+				projectId: 'test-project',
+				dataset: 'production',
+				token: 'write-token',
+				useCdn: false,
+			}),
+		);
+		expect(createIfNotExists).toHaveBeenCalledWith({
+			_id: 'contactSubmission-abc-123',
+			_type: 'contactSubmission',
+			firstName: 'Jane',
+			lastName: 'Doe',
+			email: 'jane@example.com',
+			reasonForMessage: 'Hello',
+			additionalInfo: 'More info',
+			submittedAt: '2026-04-01T12:00:00.000Z',
+			neonId: 'abc-123',
+			responseStatus: 'new',
+		});
+		expect(result).toEqual({ id: 'contactSubmission-abc-123', created: true });
+	});
+});

--- a/apps/frontend/src/server/contact/handleContactSubmission.ts
+++ b/apps/frontend/src/server/contact/handleContactSubmission.ts
@@ -1,12 +1,14 @@
 import { insertContactSubmission } from '@/db/client.ts';
 import { type ContactFormInput, type ContactResponse, contactFormSchema } from '@/server/contact/schema.ts';
+import { syncContactSubmissionToSanity } from '@/server/contact/syncContactSubmissionToSanity.ts';
 import { sendContactReplyEmail } from '@/server/email/zohoSmtp.ts';
 
 /**
- * Validates input, stores the submission in Neon, and sends a Zoho auto-reply.
+ * Validates input, stores the submission in Neon, mirrors it to Sanity Studio,
+ * and sends a Zoho auto-reply.
  *
- * Email failures after a successful DB write are logged but do not fail the request —
- * the user should not be told the submission failed when it was already stored.
+ * Email and Sanity failures after a successful DB write are logged but do not fail
+ * the request — the user should not be told the submission failed when it was already stored.
  */
 export async function handleContactSubmission(raw: unknown): Promise<ContactResponse> {
 	const parsed = contactFormSchema.safeParse(raw);
@@ -28,6 +30,7 @@ export async function handleContactSubmission(raw: unknown): Promise<ContactResp
 	const data: ContactFormInput = parsed.data;
 
 	let submissionId: string;
+	let submittedAt: string;
 	try {
 		const row = await insertContactSubmission({
 			firstName: data.firstName,
@@ -37,6 +40,7 @@ export async function handleContactSubmission(raw: unknown): Promise<ContactResp
 			additionalInfo: data.additionalInfo ?? '',
 		});
 		submissionId = row.id;
+		submittedAt = row.created_at;
 		console.info('[contact] Stored submission', {
 			id: submissionId,
 			email: data.email,
@@ -47,6 +51,31 @@ export async function handleContactSubmission(raw: unknown): Promise<ContactResp
 			success: false,
 			error: 'Unable to save your message. Please try again later.',
 		};
+	}
+
+	try {
+		const sanityResult = await syncContactSubmissionToSanity({
+			neonId: submissionId,
+			firstName: data.firstName,
+			lastName: data.lastName,
+			email: data.email,
+			reasonForMessage: data.reasonForMessage,
+			additionalInfo: data.additionalInfo,
+			submittedAt,
+		});
+		if (sanityResult) {
+			console.info('[contact] Synced submission to Sanity', {
+				neonId: submissionId,
+				sanityId: sanityResult.id,
+			});
+		}
+	} catch (error) {
+		// Submission is already saved in Neon — log and still return success
+		console.error('[contact] Failed to sync submission to Sanity', {
+			id: submissionId,
+			email: data.email,
+			error,
+		});
 	}
 
 	try {

--- a/apps/frontend/src/server/contact/syncContactSubmissionToSanity.ts
+++ b/apps/frontend/src/server/contact/syncContactSubmissionToSanity.ts
@@ -1,0 +1,82 @@
+import { apiVersion, dataset, projectId } from '@/sanity/projectDetails.ts';
+import { createClient, type SanityClient } from '@sanity/client';
+
+export interface ContactSubmissionSanityInput {
+	neonId: string;
+	firstName: string;
+	lastName: string;
+	email: string;
+	reasonForMessage: string;
+	additionalInfo?: string | null;
+	submittedAt: string;
+}
+
+/** Deterministic Sanity document id for a Neon row (idempotent creates). */
+export function contactSubmissionDocumentId(neonId: string): string {
+	// Sanity document ids: a-zA-Z0-9._- ; UUID hyphens are fine
+	return `contactSubmission-${neonId}`;
+}
+
+let writeClient: SanityClient | null = null;
+
+/**
+ * Server-only Sanity client with a write token.
+ * Returns null when SANITY_WRITE_TOKEN is not configured (sync is skipped).
+ */
+export function getSanityWriteClient(): SanityClient | null {
+	const token = process.env.SANITY_WRITE_TOKEN;
+	if (!token) {
+		return null;
+	}
+	if (!writeClient) {
+		writeClient = createClient({
+			projectId,
+			dataset,
+			apiVersion,
+			token,
+			useCdn: false,
+			perspective: 'raw',
+		});
+	}
+	return writeClient;
+}
+
+/**
+ * Creates a contactSubmission document in Sanity if one does not already exist for this neonId.
+ * Idempotent via fixed document id `contactSubmission-{neonId}`.
+ *
+ * Throws on API/network errors so the caller can log and soft-fail.
+ * No-ops (returns null) when SANITY_WRITE_TOKEN is missing.
+ */
+export async function syncContactSubmissionToSanity(
+	input: ContactSubmissionSanityInput,
+): Promise<{ id: string; created: boolean } | null> {
+	const client = getSanityWriteClient();
+	if (!client) {
+		console.warn('[contact] SANITY_WRITE_TOKEN not set; skipping Sanity sync', {
+			neonId: input.neonId,
+		});
+		return null;
+	}
+
+	const documentId = contactSubmissionDocumentId(input.neonId);
+
+	const result = await client.createIfNotExists({
+		_id: documentId,
+		_type: 'contactSubmission',
+		firstName: input.firstName,
+		lastName: input.lastName,
+		email: input.email,
+		reasonForMessage: input.reasonForMessage,
+		additionalInfo: input.additionalInfo || undefined,
+		submittedAt: input.submittedAt,
+		neonId: input.neonId,
+		responseStatus: 'new',
+	});
+
+	// createIfNotExists returns the existing doc if already present; _createdAt equals
+	// when Sanity first created it — not a perfect "created" flag, but we only care that it exists.
+	const created = result._id === documentId;
+
+	return { id: result._id, created };
+}

--- a/apps/studio/sanity.cli.ts
+++ b/apps/studio/sanity.cli.ts
@@ -5,11 +5,13 @@ export default defineCliConfig({
 		projectId: process.env.SANITY_STUDIO_PROJECT_ID!,
 		dataset: process.env.SANITY_STUDIO_DATASET!,
 	},
+	studioHost: 'capecodworld',
 	deployment: {
 		/**
 		 * Enable auto-updates for studios.
 		 * Learn more at https://www.sanity.io/docs/cli#auto-updates
 		 */
 		autoUpdates: false,
+		appId: 'xctmybtdukbkadm32496by0a',
 	},
 });

--- a/apps/studio/schema.json
+++ b/apps/studio/schema.json
@@ -778,6 +778,120 @@
 		}
 	},
 	{
+		"name": "contactSubmission",
+		"type": "document",
+		"attributes": {
+			"_id": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "string"
+				}
+			},
+			"_type": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "string",
+					"value": "contactSubmission"
+				}
+			},
+			"_createdAt": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "string"
+				}
+			},
+			"_updatedAt": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "string"
+				}
+			},
+			"_rev": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "string"
+				}
+			},
+			"firstName": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "string"
+				},
+				"optional": true
+			},
+			"lastName": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "string"
+				},
+				"optional": true
+			},
+			"email": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "string"
+				},
+				"optional": true
+			},
+			"reasonForMessage": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "string"
+				},
+				"optional": true
+			},
+			"additionalInfo": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "string"
+				},
+				"optional": true
+			},
+			"submittedAt": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "string"
+				},
+				"optional": true
+			},
+			"neonId": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "string"
+				},
+				"optional": true
+			},
+			"responseStatus": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "string"
+				},
+				"optional": true
+			},
+			"responseCategory": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "string"
+				},
+				"optional": true
+			},
+			"internalNotes": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "string"
+				},
+				"optional": true
+			},
+			"lastContactedAt": {
+				"type": "objectAttribute",
+				"value": {
+					"type": "string"
+				},
+				"optional": true
+			}
+		}
+	},
+	{
 		"name": "workProject",
 		"type": "document",
 		"attributes": {

--- a/apps/studio/src/schemaTypes/documentTypes/contactSubmission.ts
+++ b/apps/studio/src/schemaTypes/documentTypes/contactSubmission.ts
@@ -1,0 +1,160 @@
+import { Mail } from 'lucide-react';
+import { defineField, defineType } from 'sanity';
+
+export const RESPONSE_STATUS_OPTIONS = [
+	{ title: 'New', value: 'new' },
+	{ title: 'In progress', value: 'in_progress' },
+	{ title: 'Replied', value: 'replied' },
+	{ title: 'Closed', value: 'closed' },
+	{ title: 'Spam', value: 'spam' },
+] as const;
+
+export const RESPONSE_CATEGORY_OPTIONS = [
+	{ title: 'General', value: 'general' },
+	{ title: 'Audit request', value: 'audit_request' },
+	{ title: 'Partnership', value: 'partnership' },
+	{ title: 'Support', value: 'support' },
+	{ title: 'Other', value: 'other' },
+] as const;
+
+/**
+ * Contact form submissions mirrored from Neon into Studio for editorial follow-up.
+ * Form fields are read-only; editors update status, category, and internal notes.
+ */
+export const contactSubmission = defineType({
+	name: 'contactSubmission',
+	title: 'Contact submission',
+	type: 'document',
+	icon: Mail,
+	// Submissions are created by the frontend write path; discourage manual creates.
+	// Editors still need create: false at role level if available — UI hides new button via structure.
+	fields: [
+		defineField({
+			name: 'firstName',
+			title: 'First name',
+			type: 'string',
+			readOnly: true,
+			validation: (Rule) => Rule.required(),
+		}),
+		defineField({
+			name: 'lastName',
+			title: 'Last name',
+			type: 'string',
+			readOnly: true,
+			validation: (Rule) => Rule.required(),
+		}),
+		defineField({
+			name: 'email',
+			title: 'Email',
+			type: 'string',
+			readOnly: true,
+			validation: (Rule) => Rule.required().email(),
+		}),
+		defineField({
+			name: 'reasonForMessage',
+			title: 'Reason for message',
+			type: 'string',
+			readOnly: true,
+			validation: (Rule) => Rule.required(),
+		}),
+		defineField({
+			name: 'additionalInfo',
+			title: 'Additional info',
+			type: 'text',
+			rows: 4,
+			readOnly: true,
+		}),
+		defineField({
+			name: 'submittedAt',
+			title: 'Submitted at',
+			type: 'datetime',
+			readOnly: true,
+			validation: (Rule) => Rule.required(),
+		}),
+		defineField({
+			name: 'neonId',
+			title: 'Neon row ID',
+			type: 'string',
+			description: 'UUID from Neon contact_submissions for idempotency / linking',
+			readOnly: true,
+			validation: (Rule) => Rule.required(),
+		}),
+		defineField({
+			name: 'responseStatus',
+			title: 'Response status',
+			type: 'string',
+			options: {
+				list: [...RESPONSE_STATUS_OPTIONS],
+				layout: 'radio',
+			},
+			initialValue: 'new',
+			validation: (Rule) => Rule.required(),
+		}),
+		defineField({
+			name: 'responseCategory',
+			title: 'Response category',
+			type: 'string',
+			options: {
+				list: [...RESPONSE_CATEGORY_OPTIONS],
+				layout: 'dropdown',
+			},
+		}),
+		defineField({
+			name: 'internalNotes',
+			title: 'Internal notes',
+			type: 'text',
+			rows: 4,
+			description: 'Editor-only follow-up notes (not shown to the submitter)',
+		}),
+		defineField({
+			name: 'lastContactedAt',
+			title: 'Last contacted at',
+			type: 'datetime',
+		}),
+	],
+	orderings: [
+		{
+			title: 'Submitted at, newest',
+			name: 'submittedAtDesc',
+			by: [{ field: 'submittedAt', direction: 'desc' }],
+		},
+		{
+			title: 'Submitted at, oldest',
+			name: 'submittedAtAsc',
+			by: [{ field: 'submittedAt', direction: 'asc' }],
+		},
+		{
+			title: 'Status',
+			name: 'responseStatusAsc',
+			by: [
+				{ field: 'responseStatus', direction: 'asc' },
+				{ field: 'submittedAt', direction: 'desc' },
+			],
+		},
+	],
+	preview: {
+		select: {
+			firstName: 'firstName',
+			lastName: 'lastName',
+			email: 'email',
+			status: 'responseStatus',
+			submittedAt: 'submittedAt',
+			reason: 'reasonForMessage',
+		},
+		prepare({ firstName, lastName, email, status, submittedAt, reason }) {
+			const name = [firstName, lastName].filter(Boolean).join(' ') || 'Unknown';
+			const when = submittedAt
+				? new Date(submittedAt).toLocaleString(undefined, {
+						dateStyle: 'medium',
+						timeStyle: 'short',
+					})
+				: '';
+			const statusLabel =
+				RESPONSE_STATUS_OPTIONS.find((o) => o.value === status)?.title ?? status ?? 'new';
+			return {
+				title: `${name} · ${statusLabel}`,
+				subtitle: [email, reason, when].filter(Boolean).join(' · '),
+			};
+		},
+	},
+});

--- a/apps/studio/src/schemaTypes/documentTypes/index.ts
+++ b/apps/studio/src/schemaTypes/documentTypes/index.ts
@@ -1,4 +1,5 @@
 import { category } from './category';
+import { contactSubmission } from './contactSubmission';
 import { home } from './home';
 import { person } from './person';
 import { post } from './post';
@@ -6,4 +7,13 @@ import { siteSettings } from './siteSettings';
 import { testimonial } from './testimonial';
 import { workProject } from './workProject';
 
-export const documentTypes = [home, post, category, person, testimonial, workProject, siteSettings];
+export const documentTypes = [
+	home,
+	post,
+	category,
+	person,
+	testimonial,
+	workProject,
+	siteSettings,
+	contactSubmission,
+];

--- a/apps/studio/src/structure/index.ts
+++ b/apps/studio/src/structure/index.ts
@@ -1,5 +1,5 @@
 import { sanityTypeLiterals } from '@santan/shared/types';
-import { Briefcase, Home, Quote, Settings, Tags, Users } from 'lucide-react';
+import { Briefcase, Home, Mail, Quote, Settings, Tags, Users } from 'lucide-react';
 import DocumentsPane from 'sanity-plugin-documents-pane';
 import type { DefaultDocumentNodeResolver, StructureBuilder, StructureResolver } from 'sanity/structure';
 
@@ -29,6 +29,78 @@ export const structure: StructureResolver = (S) =>
 			S.documentTypeListItem('category').title('Pages').icon(Tags),
 			S.documentTypeListItem('testimonial').title('Testimonials').icon(Quote),
 			S.documentTypeListItem('workProject').title('Our Work').icon(Briefcase),
+			S.divider(),
+			// Contact submissions (created by form sync; not manually authored)
+			S.listItem()
+				.icon(Mail)
+				.id('contactSubmissions')
+				.title('Contact submissions')
+				.child(
+					S.list()
+						.id('contactSubmissionsMenu')
+						.title('Contact submissions')
+						.items([
+							S.listItem()
+								.id('contactSubmissionsAll')
+								.title('All submissions')
+								.child(
+									S.documentTypeList('contactSubmission')
+										.title('All submissions')
+										.defaultOrdering([{ field: 'submittedAt', direction: 'desc' }])
+										.canHandleIntent(() => false),
+								),
+							S.listItem()
+								.id('contactSubmissionsNew')
+								.title('New')
+								.child(
+									S.documentList()
+										.id('contactSubmissionsNewList')
+										.title('New')
+										.schemaType('contactSubmission')
+										.filter('_type == "contactSubmission" && responseStatus == "new"')
+										.defaultOrdering([{ field: 'submittedAt', direction: 'desc' }])
+										.canHandleIntent(() => false),
+								),
+							S.listItem()
+								.id('contactSubmissionsInProgress')
+								.title('In progress')
+								.child(
+									S.documentList()
+										.id('contactSubmissionsInProgressList')
+										.title('In progress')
+										.schemaType('contactSubmission')
+										.filter('_type == "contactSubmission" && responseStatus == "in_progress"')
+										.defaultOrdering([{ field: 'submittedAt', direction: 'desc' }])
+										.canHandleIntent(() => false),
+								),
+							S.listItem()
+								.id('contactSubmissionsReplied')
+								.title('Replied')
+								.child(
+									S.documentList()
+										.id('contactSubmissionsRepliedList')
+										.title('Replied')
+										.schemaType('contactSubmission')
+										.filter('_type == "contactSubmission" && responseStatus == "replied"')
+										.defaultOrdering([{ field: 'submittedAt', direction: 'desc' }])
+										.canHandleIntent(() => false),
+								),
+							S.listItem()
+								.id('contactSubmissionsClosed')
+								.title('Closed / spam')
+								.child(
+									S.documentList()
+										.id('contactSubmissionsClosedList')
+										.title('Closed / spam')
+										.schemaType('contactSubmission')
+										.filter(
+											'_type == "contactSubmission" && responseStatus in ["closed", "spam"]',
+										)
+										.defaultOrdering([{ field: 'submittedAt', direction: 'desc' }])
+										.canHandleIntent(() => false),
+								),
+						]),
+				),
 			S.divider(),
 			S.documentTypeListItem('person').title('Persons').icon(Users), //Plural
 		]);

--- a/docs/CONTACT_FORM.md
+++ b/docs/CONTACT_FORM.md
@@ -1,22 +1,27 @@
-# Contact Form (Neon + Zoho SMTP)
+# Contact Form (Neon + Zoho SMTP + Sanity)
 
-The contact form at `/contact` stores submissions in a **Neon** Postgres database and sends an automated reply via **Zoho Mail SMTP**.
+The contact form at `/contact` stores submissions in a **Neon** Postgres database, mirrors them into **Sanity Studio** for editorial follow-up, and sends an automated reply via **Zoho Mail SMTP**.
 
 ## Architecture
 
 ```
 Browser → POST /api/contact → validate (Zod)
-                          → INSERT contact_submissions (Neon)
-                          → send auto-reply (Zoho SMTP)
+                          → INSERT contact_submissions (Neon)          [required]
+                          → create contactSubmission (Sanity)          [soft-fail]
+                          → send auto-reply (Zoho SMTP)                [soft-fail]
                           → JSON { success, id }
 ```
 
 - **API route:** `apps/frontend/src/routes/api.contact.ts`
 - **Business logic:** `apps/frontend/src/server/contact/handleContactSubmission.ts`
 - **DB:** `apps/frontend/src/db/client.ts` (creates table on first use)
+- **Sanity sync:** `apps/frontend/src/server/contact/syncContactSubmissionToSanity.ts`
 - **Email:** `apps/frontend/src/server/email/zohoSmtp.ts`
+- **Studio schema:** `apps/studio/src/schemaTypes/documentTypes/contactSubmission.ts`
 
-## Database schema
+Neon remains the durable app store of record. Sanity is a **mirror** for non-technical editors to view leads and track response status.
+
+## Database schema (Neon)
 
 Table `contact_submissions` (auto-created if missing):
 
@@ -30,18 +35,51 @@ Table `contact_submissions` (auto-created if missing):
 | `additional_info`    | TEXT        | Optional                       |
 | `created_at`         | TIMESTAMPTZ | Default `NOW()`                |
 
+## Sanity schema (`contactSubmission`)
+
+| Field              | Type     | Notes |
+|--------------------|----------|--------|
+| `firstName`        | string   | Read-only (from form) |
+| `lastName`         | string   | Read-only |
+| `email`            | string   | Read-only |
+| `reasonForMessage` | string   | Read-only |
+| `additionalInfo`   | text     | Read-only |
+| `submittedAt`      | datetime | Read-only (from Neon `created_at`) |
+| `neonId`           | string   | Neon UUID; used for idempotency |
+| `responseStatus`   | string   | `new` \| `in_progress` \| `replied` \| `closed` \| `spam` |
+| `responseCategory` | string   | Optional: `general`, `audit_request`, `partnership`, `support`, `other` |
+| `internalNotes`    | text     | Editor-only |
+| `lastContactedAt`  | datetime | Optional |
+
+Document id is deterministic: `contactSubmission-{neonId}` via `createIfNotExists`, so retries do not duplicate docs.
+
+Studio: **Contact submissions** desk section with filters (All / New / In progress / Replied / Closed & spam), sorted by `submittedAt` desc.
+
 ## Environment variables
 
-Set these in `apps/frontend/.env.local`, in Vercel project settings, and as **GitHub Actions secrets** (used by `.github/workflows/e2e-tests.yml`):
+Set these in `apps/frontend/.env.local`, in Vercel project settings, and as **GitHub Actions secrets** where e2e needs real backend (mocked e2e does not require write token):
 
 | Variable          | Required | Description                                      |
 |-------------------|----------|--------------------------------------------------|
 | `DATABASE_URL`    | Yes      | Neon connection string (pooled recommended)      |
+| `SANITY_WRITE_TOKEN` | Yes*  | Server-only Sanity token with create permission on `contactSubmission`. *Required to appear in Studio; form still succeeds without it (sync skipped + warning log). |
 | `ZOHO_SMTP_HOST`  | No       | Default `smtp.zoho.com`                          |
 | `ZOHO_SMTP_PORT`  | No       | Default `465` (SSL). Use `587` for STARTTLS    |
 | `ZOHO_SMTP_USER`  | Yes      | Zoho mailbox username                            |
 | `ZOHO_SMTP_PASS`  | Yes      | Zoho password or app-specific password           |
 | `ZOHO_SMTP_FROM`  | No       | From address (defaults to `ZOHO_SMTP_USER`)      |
+
+### Sanity write token
+
+1. Open [sanity.io/manage](https://www.sanity.io/manage) → your project → **API** → **Tokens**.
+2. Create a token with **Editor** (or a custom role that can create `contactSubmission` documents).
+3. Set `SANITY_WRITE_TOKEN` only on the server (Vercel / `.env.local`). **Never** use a `VITE_` prefix.
+4. After schema changes, regenerate types:
+
+```bash
+cd apps/studio && npm run generate-types
+npm run build --workspace=@santan/shared
+```
 
 ### Neon setup
 
@@ -53,13 +91,15 @@ The app runs `CREATE TABLE IF NOT EXISTS` on first submission; no manual migrati
 
 ### GitHub Actions secrets
 
-Required for e2e CI (production server under Playwright):
+Required for e2e CI when not fully mocked:
 
 ```bash
 gh secret set DATABASE_URL
 gh secret set ZOHO_SMTP_USER
 gh secret set ZOHO_SMTP_PASS
 gh secret set ZOHO_SMTP_FROM
+# Optional for CI unless e2e asserts Sanity docs:
+# gh secret set SANITY_WRITE_TOKEN
 ```
 
 Or pipe from local env (do not log values):
@@ -83,10 +123,12 @@ printf '%s' "$DATABASE_URL" | gh secret set DATABASE_URL
 |---------------------------------|--------------------------------------------------------------------------|
 | Validation error                | `400` with `fieldErrors` map; nothing stored                             |
 | Database error                  | `500`; logged as `[contact] Failed to store submission`                  |
+| Sanity sync error after DB      | Still `200` success; logged as `[contact] Failed to sync submission to Sanity` |
+| Missing `SANITY_WRITE_TOKEN`    | Still `200` success; warning log; no Sanity doc                          |
 | Email error after successful DB | Still `200` success; logged as `[contact] Failed to send reply email`    |
 | Invalid JSON body               | `400`                                                                    |
 
-## Local testing without real SMTP/DB
+## Local testing without real SMTP/DB/Sanity
 
 Point e2e or manual UI tests at a mocked `/api/contact` (see `e2e/contact.spec.ts`).
 

--- a/packages/shared/src/types/sanity.types.ts
+++ b/packages/shared/src/types/sanity.types.ts
@@ -136,6 +136,25 @@ export type SiteSettings = {
   };
 };
 
+export type ContactSubmission = {
+  _id: string;
+  _type: "contactSubmission";
+  _createdAt: string;
+  _updatedAt: string;
+  _rev: string;
+  firstName?: string;
+  lastName?: string;
+  email?: string;
+  reasonForMessage?: string;
+  additionalInfo?: string;
+  submittedAt?: string;
+  neonId?: string;
+  responseStatus?: string;
+  responseCategory?: string;
+  internalNotes?: string;
+  lastContactedAt?: string;
+};
+
 export type WorkProject = {
   _id: string;
   _type: "workProject";
@@ -437,6 +456,7 @@ export type AllSanitySchemaTypes =
   | ImageCarousel
   | Accordion
   | SiteSettings
+  | ContactSubmission
   | WorkProject
   | SanityImageCrop
   | SanityImageHotspot

--- a/packages/shared/src/types/sanityTypeLiterals.ts
+++ b/packages/shared/src/types/sanityTypeLiterals.ts
@@ -10,6 +10,7 @@ export enum sanityTypeLiterals {
 	imageCarousel = 'imageCarousel',
 	accordion = 'accordion',
 	siteSettings = 'siteSettings',
+	contactSubmission = 'contactSubmission',
 	workProject = 'workProject',
 	sanity_imageCrop = 'sanity.imageCrop',
 	sanity_imageHotspot = 'sanity.imageHotspot',


### PR DESCRIPTION
## Summary
- Add `contactSubmission` Sanity schema and Studio desk (status filters, editor notes).
- After Neon insert, mirror each form submission into Sanity via `SANITY_WRITE_TOKEN` (`createIfNotExists` by `neonId`).
- Soft-fail Sanity/email errors so the user-facing form still succeeds; update env/docs/tests.

Closes #60

## Test plan
- [x] Unit tests for handler + Sanity sync soft-fail / missing token
- [x] Local form submit creates Neon row and Sanity doc when `SANITY_WRITE_TOKEN` is valid Editor token for project
- [x] Studio shows **Contact submissions** with response status fields after deploy
- [ ] Confirm `SANITY_WRITE_TOKEN` is set in Vercel for production